### PR TITLE
docs: add readme skeleton to ouro-result

### DIFF
--- a/packages/ouro-result/README.md
+++ b/packages/ouro-result/README.md
@@ -1,0 +1,1 @@
+# ouro-result


### PR DESCRIPTION
Looks like I forgot to add a README in #26 