### PR TITLE
feat: add drop method to producers and adapters 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ branches:
 cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
-  - '%LOCALAPPDATA%\Yarn'
 platform: x64
 environment:
   nodejs_version: 8

--- a/packages/ouro-core/src/__tests__/ouro.js
+++ b/packages/ouro-core/src/__tests__/ouro.js
@@ -172,6 +172,10 @@ describe('Methods', () => {
     expect(ouro.range(1, 10).count()).toBe(10)
   })
 
+  test('#drop()', () => {
+    expect(ouro.range().drop()).toBeUndefined()
+  })
+
   test('#every()', () => {
     {
       const fn = jest.fn(num => num < 10)

--- a/packages/ouro-core/src/adapter/__tests__/chain.js
+++ b/packages/ouro-core/src/adapter/__tests__/chain.js
@@ -8,13 +8,29 @@ let subj
 beforeEach(() => {
   const producerA = ouro.of(1, 2, 3).producer
   const producerB = ouro.of(4, 5, 6).producer
+
   subj = new Chain(producerA, producerB)
+  // $FlowIgnore
+  subj.producerA.drop = jest.fn()
+  // $FlowIgnore
+  subj.producerB.drop = jest.fn()
+})
+
+afterEach(() => {
+  subj.producerA.drop.mockReset()
+  subj.producerB.drop.mockReset()
 })
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.producerA.drop).toHaveBeenCalled()
+  expect(subj.producerB.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/__tests__/enumerate.js
+++ b/packages/ouro-core/src/adapter/__tests__/enumerate.js
@@ -7,13 +7,25 @@ let subj
 
 beforeEach(() => {
   const { producer } = ouro.of(1, 2, 3)
+
   subj = new Enumerate(producer)
+  // $FlowIgnore
+  subj.producer.drop = jest.fn()
+})
+
+afterEach(() => {
+  subj.producer.drop.mockReset()
 })
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.producer.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/__tests__/filter-map.js
+++ b/packages/ouro-core/src/adapter/__tests__/filter-map.js
@@ -7,13 +7,25 @@ let subj
 
 beforeEach(() => {
   const { producer } = ouro.of(1, null, 2, undefined, 3)
+
   subj = new FilterMap(producer, value => value)
+  // $FlowIgnore
+  subj.producer.drop = jest.fn()
+})
+
+afterEach(() => {
+  subj.producer.drop.mockReset()
 })
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.producer.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/__tests__/filter.js
+++ b/packages/ouro-core/src/adapter/__tests__/filter.js
@@ -7,13 +7,25 @@ let subj
 
 beforeEach(() => {
   const { producer } = ouro.of(1, 2, 3)
+
   subj = new Filter(producer, value => value > 1)
+  // $FlowIgnore
+  subj.producer.drop = jest.fn()
+})
+
+afterEach(() => {
+  subj.producer.drop.mockReset()
 })
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.producer.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/__tests__/flat-map.js
+++ b/packages/ouro-core/src/adapter/__tests__/flat-map.js
@@ -5,15 +5,32 @@ import * as ouro from '../../'
 
 let subj
 
+const flatMap = producer => {
+  const adapter = new FlatMap(producer, item => ouro.repeat(item).take(2))
+
+  // $FlowIgnore
+  adapter.parent.drop = jest.fn()
+  return adapter
+}
+
 beforeEach(() => {
   const { producer } = ouro.of(1, 2, 3)
-  subj = new FlatMap(producer, item => ouro.repeat(item).take(2))
+  subj = flatMap(producer)
+})
+
+afterEach(() => {
+  subj.parent.drop.mockReset()
 })
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.parent.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/__tests__/map.js
+++ b/packages/ouro-core/src/adapter/__tests__/map.js
@@ -7,13 +7,25 @@ let subj
 
 beforeEach(() => {
   const { producer } = ouro.of(1, 2, 3)
+
   subj = new Map(producer, value => value * 2)
+  // $FlowIgnore
+  subj.producer.drop = jest.fn()
+})
+
+afterEach(() => {
+  subj.producer.drop.mockReset()
 })
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.producer.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/__tests__/skip-while.js
+++ b/packages/ouro-core/src/adapter/__tests__/skip-while.js
@@ -7,13 +7,25 @@ let subj
 
 beforeEach(() => {
   const { producer } = ouro.of(1, 2, 3, 4, 5, 6)
+
   subj = new SkipWhile(producer, value => value <= 3)
+  // $FlowIgnore
+  subj.producer.drop = jest.fn()
+})
+
+afterEach(() => {
+  subj.producer.drop.mockReset()
 })
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.producer.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/__tests__/skip.js
+++ b/packages/ouro-core/src/adapter/__tests__/skip.js
@@ -7,13 +7,25 @@ let subj
 
 beforeEach(() => {
   const { producer } = ouro.of(1, 2, 3, 4, 5, 6)
+
   subj = new Skip(producer, 3)
+  // $FlowIgnore
+  subj.producer.drop = jest.fn()
+})
+
+afterEach(() => {
+  subj.producer.drop.mockReset()
 })
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.producer.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/__tests__/take-while.js
+++ b/packages/ouro-core/src/adapter/__tests__/take-while.js
@@ -7,13 +7,25 @@ let subj
 
 beforeEach(() => {
   const { producer } = ouro.of(1, 2, 3, 4, 5, 6)
+
   subj = new TakeWhile(producer, value => value <= 3)
+  // $FlowIgnore
+  subj.producer.drop = jest.fn()
+})
+
+afterEach(() => {
+  subj.producer.drop.mockReset()
 })
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.producer.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/__tests__/take.js
+++ b/packages/ouro-core/src/adapter/__tests__/take.js
@@ -7,13 +7,25 @@ let subj
 
 beforeEach(() => {
   const { producer } = ouro.repeat('test')
+
   subj = new Take(producer, 3)
+  // $FlowIgnore
+  subj.producer.drop = jest.fn()
+})
+
+afterEach(() => {
+  subj.producer.drop.mockReset()
 })
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.producer.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/__tests__/tap.js
+++ b/packages/ouro-core/src/adapter/__tests__/tap.js
@@ -8,15 +8,26 @@ let subj
 
 beforeEach(() => {
   const { producer } = ouro.of(1, 2, 3)
+
   subj = new Tap(producer, fn)
+  // $FlowIgnore
+  subj.producer.drop = jest.fn()
 })
 
-afterEach(fn.mockReset)
+afterEach(() => {
+  fn.mockReset()
+  subj.producer.drop.mockReset()
+})
 
 test('#@@iterator()', () => {
   for (const item of subj) {
     expect(item).toMatchSnapshot()
   }
+})
+
+test('#drop()', () => {
+  expect(subj.drop()).toBeUndefined()
+  expect(subj.producer.drop).toHaveBeenCalled()
 })
 
 test('#next()', () => {

--- a/packages/ouro-core/src/adapter/chain.js
+++ b/packages/ouro-core/src/adapter/chain.js
@@ -4,17 +4,23 @@ import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
 import { createProducer } from '../producer'
+import type { Drop } from '../types'
 
 @ToString
 @AsIterator
-export default class Chain<T, U> implements Iterator<T | U> {
+export default class Chain<T, U> implements Drop, Iterator<T | U> {
   /*:: @@iterator: () => Iterator<T | U> */
-  producerA: Iterator<T>
-  producerB: Iterator<U>
+  producerA: Drop & Iterator<T>
+  producerB: Drop & Iterator<U>
 
-  constructor(producerA: Iterator<T>, producerB: Iterable<U> | U) {
+  constructor(producerA: Drop & Iterator<T>, producerB: Iterable<U> | U) {
     this.producerA = producerA
     this.producerB = createProducer(producerB)
+  }
+
+  drop(): void {
+    this.producerA.drop()
+    this.producerB.drop()
   }
 
   next(): IteratorResult<T | U, void> {

--- a/packages/ouro-core/src/adapter/enumerate.js
+++ b/packages/ouro-core/src/adapter/enumerate.js
@@ -3,16 +3,22 @@
 import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../types'
+
 @ToString
 @AsIterator
-export default class Enumerate<T> implements Iterator<[number, T]> {
+export default class Enumerate<T> implements Drop, Iterator<[number, T]> {
   /*:: @@iterator: () => Iterator<[number, T]> */
-  producer: Iterator<T>
+  producer: Drop & Iterator<T>
   state: number
 
-  constructor(producer: Iterator<T>) {
+  constructor(producer: Drop & Iterator<T>) {
     this.producer = producer
     this.state = 0
+  }
+
+  drop(): void {
+    this.producer.drop()
   }
 
   next(): IteratorResult<[number, T], void> {

--- a/packages/ouro-core/src/adapter/filter-map.js
+++ b/packages/ouro-core/src/adapter/filter-map.js
@@ -3,6 +3,8 @@
 import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../types'
+
 function exec<T, U>(adapter: FilterMap<T, U>): IteratorResult<U, void> {
   const next = adapter.producer.next()
 
@@ -21,14 +23,18 @@ function exec<T, U>(adapter: FilterMap<T, U>): IteratorResult<U, void> {
 
 @ToString
 @AsIterator
-export default class FilterMap<T, U> implements Iterator<U> {
+export default class FilterMap<T, U> implements Drop, Iterator<U> {
   /*:: @@iterator: () => Iterator<U> */
   fn: T => ?U
-  producer: Iterator<T>
+  producer: Drop & Iterator<T>
 
-  constructor(producer: Iterator<T>, fn: T => ?U) {
+  constructor(producer: Drop & Iterator<T>, fn: T => ?U) {
     this.fn = fn
     this.producer = producer
+  }
+
+  drop(): void {
+    this.producer.drop()
   }
 
   next(): IteratorResult<U, void> {

--- a/packages/ouro-core/src/adapter/filter.js
+++ b/packages/ouro-core/src/adapter/filter.js
@@ -2,6 +2,8 @@
 
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../types'
+
 function exec<T>(adapter: Filter<T>): IteratorResult<T, void> {
   const next = adapter.producer.next()
 
@@ -14,14 +16,18 @@ function exec<T>(adapter: Filter<T>): IteratorResult<T, void> {
 
 @ToString
 @AsIterator
-export default class Filter<T> implements Iterator<T> {
+export default class Filter<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
   fn: T => boolean
-  producer: Iterator<T>
+  producer: Drop & Iterator<T>
 
-  constructor(producer: Iterator<T>, fn: T => boolean) {
+  constructor(producer: Drop & Iterator<T>, fn: T => boolean) {
     this.fn = fn
     this.producer = producer
+  }
+
+  drop(): void {
+    this.producer.drop()
   }
 
   next(): IteratorResult<T, void> {

--- a/packages/ouro-core/src/adapter/map.js
+++ b/packages/ouro-core/src/adapter/map.js
@@ -3,16 +3,22 @@
 import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../types'
+
 @ToString
 @AsIterator
-export default class Map<T, U> implements Iterator<U> {
+export default class Map<T, U> implements Drop, Iterator<U> {
   /*:: @@iterator: () => Iterator<U> */
   fn: T => U
-  producer: Iterator<T>
+  producer: Drop & Iterator<T>
 
-  constructor(producer: Iterator<T>, fn: T => U) {
+  constructor(producer: Drop & Iterator<T>, fn: T => U) {
     this.fn = fn
     this.producer = producer
+  }
+
+  drop(): void {
+    this.producer.drop()
   }
 
   next(): IteratorResult<U, void> {

--- a/packages/ouro-core/src/adapter/skip-while.js
+++ b/packages/ouro-core/src/adapter/skip-while.js
@@ -2,6 +2,8 @@
 
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../types'
+
 function exec<T>(adapter: SkipWhile<T>): IteratorResult<T, void> {
   const next = adapter.producer.next()
 
@@ -19,16 +21,20 @@ function exec<T>(adapter: SkipWhile<T>): IteratorResult<T, void> {
 
 @ToString
 @AsIterator
-export default class SkipWhile<T> implements Iterator<T> {
+export default class SkipWhile<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
   fn: T => boolean
-  producer: Iterator<T>
+  producer: Drop & Iterator<T>
   skipped: boolean
 
-  constructor(producer: Iterator<T>, fn: T => boolean) {
+  constructor(producer: Drop & Iterator<T>, fn: T => boolean) {
     this.fn = fn
     this.producer = producer
     this.skipped = false
+  }
+
+  drop(): void {
+    this.producer.drop()
   }
 
   next(): IteratorResult<T, void> {

--- a/packages/ouro-core/src/adapter/skip.js
+++ b/packages/ouro-core/src/adapter/skip.js
@@ -2,6 +2,8 @@
 
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../types'
+
 function exec<T>(adapter: Skip<T>): IteratorResult<T, void> {
   const next = adapter.producer.next()
 
@@ -16,16 +18,20 @@ function exec<T>(adapter: Skip<T>): IteratorResult<T, void> {
 
 @ToString
 @AsIterator
-export default class Skip<T> implements Iterator<T> {
+export default class Skip<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
   amount: number
-  producer: Iterator<T>
+  producer: Drop & Iterator<T>
   calls: number
 
-  constructor(producer: Iterator<T>, amount: number) {
+  constructor(producer: Drop & Iterator<T>, amount: number) {
     this.amount = amount
     this.calls = 0
     this.producer = producer
+  }
+
+  drop(): void {
+    this.producer.drop()
   }
 
   next(): IteratorResult<T, void> {

--- a/packages/ouro-core/src/adapter/take-while.js
+++ b/packages/ouro-core/src/adapter/take-while.js
@@ -3,16 +3,22 @@
 import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../types'
+
 @ToString
 @AsIterator
-export default class TakeWhile<T> implements Iterator<T> {
+export default class TakeWhile<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
   fn: T => boolean
-  producer: Iterator<T>
+  producer: Drop & Iterator<T>
 
-  constructor(producer: Iterator<T>, fn: T => boolean) {
+  constructor(producer: Drop & Iterator<T>, fn: T => boolean) {
     this.fn = fn
     this.producer = producer
+  }
+
+  drop(): void {
+    this.producer.drop()
   }
 
   next(): IteratorResult<T, void> {

--- a/packages/ouro-core/src/adapter/take.js
+++ b/packages/ouro-core/src/adapter/take.js
@@ -3,18 +3,24 @@
 import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../types'
+
 @ToString
 @AsIterator
-export default class Take<T> implements Iterator<T> {
+export default class Take<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
   amount: number
   calls: number
-  producer: Iterator<T>
+  producer: Drop & Iterator<T>
 
-  constructor(producer: Iterator<T>, amount: number) {
+  constructor(producer: Drop & Iterator<T>, amount: number) {
     this.amount = amount
     this.calls = 0
     this.producer = producer
+  }
+
+  drop(): void {
+    this.producer.drop()
   }
 
   next(): IteratorResult<T, void> {

--- a/packages/ouro-core/src/adapter/tap.js
+++ b/packages/ouro-core/src/adapter/tap.js
@@ -2,16 +2,22 @@
 
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../types'
+
 @ToString
 @AsIterator
-export default class Tap<T> implements Iterator<T> {
+export default class Tap<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
   fn: T => void
-  producer: Iterator<T>
+  producer: Drop & Iterator<T>
 
-  constructor(producer: Iterator<T>, fn: T => void) {
+  constructor(producer: Drop & Iterator<T>, fn: T => void) {
     this.fn = fn
     this.producer = producer
+  }
+
+  drop(): void {
+    this.producer.drop()
   }
 
   next(): IteratorResult<T, void> {

--- a/packages/ouro-core/src/adapter/zip.js
+++ b/packages/ouro-core/src/adapter/zip.js
@@ -4,17 +4,23 @@ import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
 import { createProducer } from '../producer'
+import type { Drop } from '../types'
 
 @ToString
 @AsIterator
-export default class Zip<T, U> implements Iterator<[T, U]> {
+export default class Zip<T, U> implements Drop, Iterator<[T, U]> {
   /*:: @@iterator: () => Iterator<[T, U]> */
-  producerA: Iterator<T>
-  producerB: Iterator<U>
+  producerA: Drop & Iterator<T>
+  producerB: Drop & Iterator<U>
 
-  constructor(producerA: Iterator<T>, producerB: Iterable<U>) {
+  constructor(producerA: Drop & Iterator<T>, producerB: Iterable<U>) {
     this.producerA = producerA
     this.producerB = createProducer(producerB)
+  }
+
+  drop(): void {
+    this.producerA.drop()
+    this.producerB.drop()
   }
 
   next(): IteratorResult<[T, U], void> {

--- a/packages/ouro-core/src/index.js
+++ b/packages/ouro-core/src/index.js
@@ -11,9 +11,7 @@ import {
   Numbers,
   Repeat,
 } from './producer'
-import type { IndexedCollection } from './producer'
-
-export type { default as Ouro, FromIterator } from './ouro'
+import type { IndexedCollection } from './types'
 
 export const VERSION: string = pkg.version
 

--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/cycle.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/cycle.js.snap
@@ -2,7 +2,23 @@
 
 exports[`#constructor() 1`] = `
 Cycle {
+  "done": false,
   "source": "test",
+  "state": 0,
+}
+`;
+
+exports[`#drop() 1`] = `
+Object {
+  "done": true,
+  "value": undefined,
+}
+`;
+
+exports[`#drop() 2`] = `
+Cycle {
+  "done": true,
+  "source": Array [],
   "state": 0,
 }
 `;

--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/indexed.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/indexed.js.snap
@@ -17,6 +17,20 @@ Indexed {
 }
 `;
 
+exports[`Indexed source array #drop() 1`] = `
+Object {
+  "done": true,
+  "value": undefined,
+}
+`;
+
+exports[`Indexed source array #drop() 2`] = `
+Indexed {
+  "index": 0,
+  "source": Array [],
+}
+`;
+
 exports[`Indexed source string #@@iterator() 1`] = `"t"`;
 
 exports[`Indexed source string #@@iterator() 2`] = `"e"`;
@@ -29,5 +43,19 @@ exports[`Indexed source string #constructor() 1`] = `
 Indexed {
   "index": 0,
   "source": "test",
+}
+`;
+
+exports[`Indexed source string #drop() 1`] = `
+Object {
+  "done": true,
+  "value": undefined,
+}
+`;
+
+exports[`Indexed source string #drop() 2`] = `
+Indexed {
+  "index": 0,
+  "source": Array [],
 }
 `;

--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/range.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/range.js.snap
@@ -32,6 +32,27 @@ Chars {
 }
 `;
 
+exports[`Chars <- #drop() 1`] = `
+Object {
+  "done": true,
+  "value": undefined,
+}
+`;
+
+exports[`Chars <- #drop() 2`] = `
+Chars {
+  "size": 3,
+  "source": Numbers {
+    "done": true,
+    "end": 0,
+    "size": 0,
+    "start": 0,
+    "state": 0,
+    "step": 0,
+  },
+}
+`;
+
 exports[`Chars <- #next() 1`] = `
 Object {
   "done": false,
@@ -65,6 +86,27 @@ exports[`Chars -> #@@iterator() 1`] = `"a"`;
 exports[`Chars -> #@@iterator() 2`] = `"b"`;
 
 exports[`Chars -> #@@iterator() 3`] = `"c"`;
+
+exports[`Chars -> #drop() 1`] = `
+Object {
+  "done": true,
+  "value": undefined,
+}
+`;
+
+exports[`Chars -> #drop() 2`] = `
+Chars {
+  "size": 3,
+  "source": Numbers {
+    "done": true,
+    "end": 0,
+    "size": 0,
+    "start": 0,
+    "state": 0,
+    "step": 0,
+  },
+}
+`;
 
 exports[`Chars -> #next() 1`] = `
 Object {
@@ -117,6 +159,24 @@ Numbers {
   "start": 9007199254740991,
   "state": 9007199254740991,
   "step": -1,
+}
+`;
+
+exports[`Numbers <- #drop() 1`] = `
+Object {
+  "done": true,
+  "value": undefined,
+}
+`;
+
+exports[`Numbers <- #drop() 2`] = `
+Numbers {
+  "done": true,
+  "end": 0,
+  "size": 0,
+  "start": 0,
+  "state": 0,
+  "step": 0,
 }
 `;
 
@@ -198,7 +258,25 @@ exports[`Numbers -> #constructor() 5`] = `
 Numbers {
   "done": true,
   "end": 0,
-  "size": NaN,
+  "size": 0,
+  "start": 0,
+  "state": 0,
+  "step": 0,
+}
+`;
+
+exports[`Numbers -> #drop() 1`] = `
+Object {
+  "done": true,
+  "value": undefined,
+}
+`;
+
+exports[`Numbers -> #drop() 2`] = `
+Numbers {
+  "done": true,
+  "end": 0,
+  "size": 0,
   "start": 0,
   "state": 0,
   "step": 0,

--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/repeat.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/repeat.js.snap
@@ -2,6 +2,21 @@
 
 exports[`#constructor() 1`] = `
 Repeat {
+  "done": false,
   "value": "test",
+}
+`;
+
+exports[`#drop() 1`] = `
+Object {
+  "done": true,
+  "value": undefined,
+}
+`;
+
+exports[`#drop() 2`] = `
+Repeat {
+  "done": true,
+  "value": undefined,
 }
 `;

--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/unbound.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/unbound.js.snap
@@ -5,16 +5,3 @@ Unbound {
   "source":  {},
 }
 `;
-
-exports[`#drop() 1`] = `
-Object {
-  "done": true,
-  "value": undefined,
-}
-`;
-
-exports[`#drop() 2`] = `
-Unbound {
-  "source":  {},
-}
-`;

--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/unbound.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/unbound.js.snap
@@ -5,3 +5,16 @@ Unbound {
   "source":  {},
 }
 `;
+
+exports[`#drop() 1`] = `
+Object {
+  "done": true,
+  "value": undefined,
+}
+`;
+
+exports[`#drop() 2`] = `
+Unbound {
+  "source":  {},
+}
+`;

--- a/packages/ouro-core/src/producer/__tests__/cycle.js
+++ b/packages/ouro-core/src/producer/__tests__/cycle.js
@@ -25,3 +25,9 @@ test('#@@iterator()', () => {
     i += 1
   }
 })
+
+test('#drop()', () => {
+  expect(producer.drop()).toBeUndefined()
+  expect(producer.next()).toMatchSnapshot()
+  expect(producer).toMatchSnapshot()
+})

--- a/packages/ouro-core/src/producer/__tests__/indexed.js
+++ b/packages/ouro-core/src/producer/__tests__/indexed.js
@@ -21,6 +21,12 @@ describe('Indexed', () => {
         expect(item).toMatchSnapshot()
       }
     })
+
+    test('#drop()', () => {
+      expect(producer.drop()).toBeUndefined()
+      expect(producer.next()).toMatchSnapshot()
+      expect(producer).toMatchSnapshot()
+    })
   })
 
   describe('source string', () => {
@@ -40,6 +46,12 @@ describe('Indexed', () => {
       for (const item of producer) {
         expect(item).toMatchSnapshot()
       }
+    })
+
+    test('#drop()', () => {
+      expect(producer.drop()).toBeUndefined()
+      expect(producer.next()).toMatchSnapshot()
+      expect(producer).toMatchSnapshot()
     })
   })
 })

--- a/packages/ouro-core/src/producer/__tests__/range.js
+++ b/packages/ouro-core/src/producer/__tests__/range.js
@@ -25,6 +25,12 @@ describe('Numbers', () => {
       }
     })
 
+    test('#drop()', () => {
+      expect(producer.drop()).toBeUndefined()
+      expect(producer.next()).toMatchSnapshot()
+      expect(producer).toMatchSnapshot()
+    })
+
     test('#next()', () => {
       expect(producer.next()).toMatchSnapshot()
       expect(producer.next()).toMatchSnapshot()
@@ -47,6 +53,12 @@ describe('Numbers', () => {
       for (const item of producer) {
         expect(item).toMatchSnapshot()
       }
+    })
+
+    test('#drop()', () => {
+      expect(producer.drop()).toBeUndefined()
+      expect(producer.next()).toMatchSnapshot()
+      expect(producer).toMatchSnapshot()
     })
 
     test('#next()', () => {
@@ -72,6 +84,12 @@ describe('Chars', () => {
       }
     })
 
+    test('#drop()', () => {
+      expect(producer.drop()).toBeUndefined()
+      expect(producer.next()).toMatchSnapshot()
+      expect(producer).toMatchSnapshot()
+    })
+
     test('#next()', () => {
       expect(producer.next()).toMatchSnapshot()
       expect(producer.next()).toMatchSnapshot()
@@ -94,6 +112,12 @@ describe('Chars', () => {
       for (const item of producer) {
         expect(item).toMatchSnapshot()
       }
+    })
+
+    test('#drop()', () => {
+      expect(producer.drop()).toBeUndefined()
+      expect(producer.next()).toMatchSnapshot()
+      expect(producer).toMatchSnapshot()
     })
 
     test('#next()', () => {

--- a/packages/ouro-core/src/producer/__tests__/repeat.js
+++ b/packages/ouro-core/src/producer/__tests__/repeat.js
@@ -25,3 +25,9 @@ test('#@@iterator()', () => {
     i += 1
   }
 })
+
+test('#drop()', () => {
+  expect(producer.drop()).toBeUndefined()
+  expect(producer.next()).toMatchSnapshot()
+  expect(producer).toMatchSnapshot()
+})

--- a/packages/ouro-core/src/producer/__tests__/unbound.js
+++ b/packages/ouro-core/src/producer/__tests__/unbound.js
@@ -36,6 +36,4 @@ test('#@@iterator()', () => {
 
 test('#drop()', () => {
   expect(producer.drop()).toBeUndefined()
-  expect(producer.next()).toMatchSnapshot()
-  expect(producer).toMatchSnapshot()
 })

--- a/packages/ouro-core/src/producer/__tests__/unbound.js
+++ b/packages/ouro-core/src/producer/__tests__/unbound.js
@@ -33,3 +33,9 @@ test('#@@iterator()', () => {
     i += 1
   }
 })
+
+test('#drop()', () => {
+  expect(producer.drop()).toBeUndefined()
+  expect(producer.next()).toMatchSnapshot()
+  expect(producer).toMatchSnapshot()
+})

--- a/packages/ouro-core/src/producer/cycle.js
+++ b/packages/ouro-core/src/producer/cycle.js
@@ -3,21 +3,33 @@
 import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
-import type { IndexedCollection } from './'
+import type { Drop, IndexedCollection } from '../types'
 
 @ToString
 @AsIterator
-export default class Cycle<T> implements Iterator<T> {
+export default class Cycle<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
+  done: boolean
   source: IndexedCollection<T>
   state: number
 
   constructor(source: IndexedCollection<T>) {
+    this.done = false
     this.source = source
     this.state = 0
   }
 
+  drop(): void {
+    this.done = true
+    this.source = []
+    this.state = 0
+  }
+
   next(): IteratorResult<T, void> {
+    if (this.done) {
+      return result.done()
+    }
+
     if (this.state >= this.source.length) {
       this.state = 0
     }

--- a/packages/ouro-core/src/producer/index.js
+++ b/packages/ouro-core/src/producer/index.js
@@ -1,5 +1,7 @@
 // @flow
 
+import type { Drop } from '../types'
+
 import Indexed from './indexed'
 import Unbound from './unbound'
 
@@ -8,27 +10,22 @@ export { default as Cycle } from './cycle'
 export { default as Indexed } from './indexed'
 export { default as Repeat } from './repeat'
 export { default as Unbound } from './unbound'
-export type { IndexedCollection } from './indexed'
 
-export function createProducer<T>(source: any): Iterator<T> {
+export function createProducer<T>(source: any): Drop & Iterator<T> {
   if (source == null) {
     return new Indexed([])
   }
 
-  if (Array.isArray(source) || typeof source === 'string') {
+  if (Array.isArray(source)) {
     return new Indexed(source)
   }
 
-  if (source instanceof Set) {
-    return source.values()
-  }
-
-  if (source instanceof Map) {
-    return source.entries()
+  if (typeof source === 'string') {
+    return new Indexed(source)
   }
 
   if (typeof source[Symbol.iterator] === 'function') {
-    return new Unbound(source)
+    return new Unbound(source[Symbol.iterator]())
   }
 
   return new Indexed([source])

--- a/packages/ouro-core/src/producer/indexed.js
+++ b/packages/ouro-core/src/producer/indexed.js
@@ -3,14 +3,11 @@
 import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
-export interface IndexedCollection<T> extends Iterable<T> {
-  [key: number]: T,
-  length: number,
-}
+import type { Drop, IndexedCollection } from '../types'
 
 @ToString
 @AsIterator
-export default class Indexed<T> implements Iterator<T> {
+export default class Indexed<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
   index: number
   source: IndexedCollection<T>
@@ -18,6 +15,11 @@ export default class Indexed<T> implements Iterator<T> {
   constructor(source: IndexedCollection<T>) {
     this.index = 0
     this.source = source
+  }
+
+  drop(): void {
+    this.index = 0
+    this.source = []
   }
 
   next(): IteratorResult<T, void> {

--- a/packages/ouro-core/src/producer/range/chars.js
+++ b/packages/ouro-core/src/producer/range/chars.js
@@ -3,6 +3,8 @@
 import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../../types'
+
 import Numbers from './numbers'
 
 export const MIN_CHAR: string = String.fromCodePoint(0)
@@ -10,7 +12,7 @@ export const MAX_CHAR: string = String.fromCodePoint(0x10ffff)
 
 @ToString
 @AsIterator
-export default class Chars implements Iterator<string> {
+export default class Chars implements Drop, Iterator<string> {
   /*:: @@iterator: () => Iterator<string> */
   source: Numbers
   size: number
@@ -18,6 +20,10 @@ export default class Chars implements Iterator<string> {
   constructor(start?: string = MIN_CHAR, end?: string = MAX_CHAR) {
     this.source = new Numbers(start.codePointAt(0), end.codePointAt(0))
     this.size = this.source.size
+  }
+
+  drop(): void {
+    this.source.drop()
   }
 
   next(): IteratorResult<string, void> {

--- a/packages/ouro-core/src/producer/range/numbers.js
+++ b/packages/ouro-core/src/producer/range/numbers.js
@@ -3,9 +3,11 @@
 import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../../types'
+
 @ToString
 @AsIterator
-export default class Numbers implements Iterator<number> {
+export default class Numbers implements Drop, Iterator<number> {
   /*:: @@iterator: () => Iterator<number> */
   done: boolean
   end: number
@@ -21,21 +23,27 @@ export default class Numbers implements Iterator<number> {
     this.size = Math.abs(start - end) + 1
 
     if (Number.isNaN(start) || Number.isNaN(end) || this.size === 0) {
-      this.done = true
-      this.end = 0
-      this.start = 0
-      this.step = 0
+      this.drop()
     } else if (start > end) {
       this.end = end
       this.start = Number.isFinite(start) ? start : Number.MAX_SAFE_INTEGER
       this.step = -1
+      this.state = this.start
     } else {
       this.end = Number.isFinite(end) ? end : Number.MAX_SAFE_INTEGER
       this.start = start
       this.step = 1
+      this.state = this.start
     }
+  }
 
-    this.state = this.start
+  drop(): void {
+    this.done = true
+    this.end = 0
+    this.size = 0
+    this.start = 0
+    this.state = 0
+    this.step = 0
   }
 
   next(): IteratorResult<number, void> {

--- a/packages/ouro-core/src/producer/repeat.js
+++ b/packages/ouro-core/src/producer/repeat.js
@@ -3,17 +3,31 @@
 import * as result from 'ouro-result'
 import { AsIterator, ToString } from 'ouro-traits'
 
+import type { Drop } from '../types'
+
 @ToString
 @AsIterator
-export default class Repeat<T> implements Iterator<T> {
+export default class Repeat<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
+  done: boolean
   value: T
 
   constructor(value: T) {
+    this.done = false
     this.value = value
   }
 
+  drop(): void {
+    this.done = true
+    // $FlowIgnore
+    this.value = undefined
+  }
+
   next(): IteratorResult<T, void> {
+    if (this.done) {
+      return result.done()
+    }
+
     return result.next(this.value)
   }
 }

--- a/packages/ouro-core/src/producer/unbound.js
+++ b/packages/ouro-core/src/producer/unbound.js
@@ -1,16 +1,22 @@
 // @flow
 
 import { AsIterator, ToString } from 'ouro-traits'
+import type { Drop } from '../types'
 
 @ToString
 @AsIterator
-export default class Unbound<T> implements Iterator<T> {
+export default class Unbound<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
-  source: Iterator<T>
+  source: (Drop & Iterator<T>) | Iterator<T>
 
-  constructor(source: Iterable<T>) {
-    // $FlowIgnore
-    this.source = source[Symbol.iterator]()
+  constructor(source: Iterator<T>) {
+    this.source = source
+  }
+
+  drop(): void {
+    if (typeof this.source.drop === 'function') {
+      this.source.drop()
+    }
   }
 
   next(): IteratorResult<T, void> {

--- a/packages/ouro-core/src/types.js
+++ b/packages/ouro-core/src/types.js
@@ -1,0 +1,15 @@
+// @flow
+
+export interface Drop {
+  drop(): void,
+}
+
+export interface FromIterator<T> {
+  constructor(source: Iterator<T>): FromIterator<T>,
+  static from(source: Iterator<T>): FromIterator<T>,
+}
+
+export interface IndexedCollection<T> extends Iterable<T> {
+  [key: number]: T,
+  length: number,
+}


### PR DESCRIPTION
Adds a `#drop()` method to adapters and producers. This will be necessary for the cleanup hooks required by more complex adapters like `Unique`.