### PR TITLE
refactor: rename ouro class to iter

### DIFF
--- a/packages/ouro-core/src/__tests__/index.js
+++ b/packages/ouro-core/src/__tests__/index.js
@@ -1,13 +1,13 @@
 // @flow
 
 import { Chars, Cycle, Numbers } from '../producer'
-import Ouro from '../ouro'
+import Iter from '../iter'
 import * as ouro from '../'
 
 test('.chars()', () => {
-  expect(ouro.chars()).toBeInstanceOf(Ouro)
-  expect(ouro.chars('a')).toBeInstanceOf(Ouro)
-  expect(ouro.chars('a', 'z')).toBeInstanceOf(Ouro)
+  expect(ouro.chars()).toBeInstanceOf(Iter)
+  expect(ouro.chars('a')).toBeInstanceOf(Iter)
+  expect(ouro.chars('a', 'z')).toBeInstanceOf(Iter)
 
   {
     const iter = ouro.chars('a', 'z')
@@ -19,30 +19,30 @@ test('.chars()', () => {
 test('.cycle()', () => {
   const iter = ouro.cycle([1, 2, 3])
 
-  expect(iter).toBeInstanceOf(Ouro)
+  expect(iter).toBeInstanceOf(Iter)
   expect(iter.producer).toBeInstanceOf(Cycle)
 })
 
 test('.from()', () => {
-  expect(ouro.from()).toBeInstanceOf(Ouro)
-  expect(ouro.from([1, 2, 3])).toBeInstanceOf(Ouro)
+  expect(ouro.from()).toBeInstanceOf(Iter)
+  expect(ouro.from([1, 2, 3])).toBeInstanceOf(Iter)
 })
 
 test('.of()', () => {
-  expect(ouro.of()).toBeInstanceOf(Ouro)
+  expect(ouro.of()).toBeInstanceOf(Iter)
 
   {
     const iter = ouro.of(1, 2, 3)
 
-    expect(iter).toBeInstanceOf(Ouro)
+    expect(iter).toBeInstanceOf(Iter)
     expect(iter.producer).toMatchSnapshot()
   }
 })
 
 test('.range()', () => {
-  expect(ouro.range()).toBeInstanceOf(Ouro)
-  expect(ouro.range(1)).toBeInstanceOf(Ouro)
-  expect(ouro.range(1, 2)).toBeInstanceOf(Ouro)
+  expect(ouro.range()).toBeInstanceOf(Iter)
+  expect(ouro.range(1)).toBeInstanceOf(Iter)
+  expect(ouro.range(1, 2)).toBeInstanceOf(Iter)
 
   {
     const iter = ouro.range(1, 2)
@@ -52,5 +52,5 @@ test('.range()', () => {
 })
 
 test('.repeat()', () => {
-  expect(ouro.repeat()).toBeInstanceOf(Ouro)
+  expect(ouro.repeat()).toBeInstanceOf(Iter)
 })

--- a/packages/ouro-core/src/__tests__/methods.js
+++ b/packages/ouro-core/src/__tests__/methods.js
@@ -134,5 +134,5 @@ test('#sum()', () => {
 })
 
 test('#toString()', () => {
-  expect(ouro.of().toString()).toBe('[object Ouro]')
+  expect(ouro.of().toString()).toBe('[object Iter]')
 })

--- a/packages/ouro-core/src/index.js
+++ b/packages/ouro-core/src/index.js
@@ -2,7 +2,7 @@
 
 import * as pkg from '../package.json'
 
-import Ouro from './ouro'
+import Iter from './iter'
 import {
   createProducer,
   Chars,
@@ -15,32 +15,32 @@ import type { IndexedCollection } from './types'
 
 export const VERSION: string = pkg.version
 
-export function chars(start?: string, end?: string): Ouro<string> {
+export function chars(start?: string, end?: string): Iter<string> {
   const producer = new Chars(start, end)
-  return new Ouro(producer)
+  return new Iter(producer)
 }
 
-export function cycle<T>(source: IndexedCollection<T>): Ouro<T> {
+export function cycle<T>(source: IndexedCollection<T>): Iter<T> {
   const producer = new Cycle(source)
-  return new Ouro(producer)
+  return new Iter(producer)
 }
 
-export function from<T>(source?: Iterable<T> | T = []): Ouro<T> {
+export function from<T>(source?: Iterable<T> | T = []): Iter<T> {
   const producer = createProducer(source)
-  return new Ouro(producer)
+  return new Iter(producer)
 }
 
-export function of<T>(...items: Array<T>): Ouro<T> {
+export function of<T>(...items: Array<T>): Iter<T> {
   const producer = new Indexed(items)
-  return new Ouro(producer)
+  return new Iter(producer)
 }
 
-export function repeat<T>(value: T): Ouro<T> {
+export function repeat<T>(value: T): Iter<T> {
   const producer = new Repeat(value)
-  return new Ouro(producer)
+  return new Iter(producer)
 }
 
-export function range(start?: number, end?: number): Ouro<number> {
+export function range(start?: number, end?: number): Iter<number> {
   const producer = new Numbers(start, end)
-  return new Ouro(producer)
+  return new Iter(producer)
 }

--- a/packages/ouro-core/src/iter.js
+++ b/packages/ouro-core/src/iter.js
@@ -22,7 +22,7 @@ import type { Drop, FromIterator } from './types'
 
 @ToString
 @AsIterator
-export default class Ouro<T> implements Drop, Iterator<T> {
+export default class Iter<T> implements Drop, Iterator<T> {
   /*:: @@iterator: () => Iterator<T> */
   producer: Drop & Iterator<T>
 
@@ -30,9 +30,9 @@ export default class Ouro<T> implements Drop, Iterator<T> {
     this.producer = producer
   }
 
-  chain<U>(producer: Iterable<U> | U): Ouro<T | U> {
+  chain<U>(producer: Iterable<U> | U): Iter<T | U> {
     const adapter = new Chain(this.producer, producer)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
   collect(Target?: Class<FromIterator<T>> = Array): FromIterator<T> {
@@ -58,23 +58,23 @@ export default class Ouro<T> implements Drop, Iterator<T> {
     this.producer.drop()
   }
 
-  enumerate(): Ouro<[number, T]> {
+  enumerate(): Iter<[number, T]> {
     const adapter = new Enumerate(this.producer)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
   every(fn: T => boolean): boolean {
     return this.find(item => !fn(item)) === undefined
   }
 
-  filterMap<U>(fn: T => ?U): Ouro<U> {
+  filterMap<U>(fn: T => ?U): Iter<U> {
     const adapter = new FilterMap(this.producer, fn)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
-  filter(fn: T => boolean): Ouro<T> {
+  filter(fn: T => boolean): Iter<T> {
     const adapter = new Filter(this.producer, fn)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
   find(fn: T => boolean): ?T {
@@ -85,12 +85,12 @@ export default class Ouro<T> implements Drop, Iterator<T> {
     return this.take(1).reduce((_, next) => next)
   }
 
-  flatMap<U>(fn: T => Iterable<U> | U): Ouro<U> {
+  flatMap<U>(fn: T => Iterable<U> | U): Iter<U> {
     const adapter = new FlatMap(this.producer, fn)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
-  flatten(): Ouro<*> {
+  flatten(): Iter<*> {
     return this.flatMap(identity)
   }
 
@@ -112,9 +112,9 @@ export default class Ouro<T> implements Drop, Iterator<T> {
     return this.reduce((_, next) => next)
   }
 
-  map<U>(fn: T => U): Ouro<U> {
+  map<U>(fn: T => U): Iter<U> {
     const adapter = new Map(this.producer, fn)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
   next(): IteratorResult<T, void> {
@@ -151,14 +151,14 @@ export default class Ouro<T> implements Drop, Iterator<T> {
     return reduce(fn, acc, this)
   }
 
-  skip(amount: number): Ouro<T> {
+  skip(amount: number): Iter<T> {
     const adapter = new Skip(this.producer, amount)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
-  skipWhile(fn: T => boolean): Ouro<T> {
+  skipWhile(fn: T => boolean): Iter<T> {
     const adapter = new SkipWhile(this.producer, fn)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
   some(fn: T => boolean): boolean {
@@ -169,28 +169,28 @@ export default class Ouro<T> implements Drop, Iterator<T> {
     return this.reduce((acc, item) => acc + +item, 0)
   }
 
-  take(amount: number): Ouro<T> {
+  take(amount: number): Iter<T> {
     const adapter = new Take(this.producer, amount)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
-  takeWhile(fn: T => boolean): Ouro<T> {
+  takeWhile(fn: T => boolean): Iter<T> {
     const adapter = new TakeWhile(this.producer, fn)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
-  tap(fn: T => void): Ouro<T> {
+  tap(fn: T => void): Iter<T> {
     const adapter = new Tap(this.producer, fn)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
-  unique(fn?: T => * = identity): Ouro<T> {
+  unique(fn?: T => * = identity): Iter<T> {
     const adapter = new Unique(this.producer, fn)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 
-  zip(producer?: Iterable<*> = this.producer): Ouro<[T, *]> {
+  zip(producer?: Iterable<*> = this.producer): Iter<[T, *]> {
     const adapter = new Zip(this.producer, producer)
-    return new Ouro(adapter)
+    return new Iter(adapter)
   }
 }

--- a/packages/ouro-core/src/producer/__tests__/index.js
+++ b/packages/ouro-core/src/producer/__tests__/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import Ouro from '../../ouro'
+import Iter from '../../iter'
 import { createProducer, Indexed, Unbound } from '../'
 
 describe('#createProducer()', () => {
@@ -32,9 +32,9 @@ describe('#createProducer()', () => {
     expect(producer.next()).toHaveProperty('value', value)
   })
 
-  test('Ouro<T> => Ouro<T>.producer', () => {
+  test('Iter<T> => Iter<T>.producer', () => {
     const source = createProducer()
-    const producer = createProducer(new Ouro(source))
+    const producer = createProducer(new Iter(source))
 
     expect(producer).toBe(producer)
   })


### PR DESCRIPTION
`Iter` is a more descriptive type than `Ouro`. This will also prevent confusion when more top level interfaces are added.