### PR TITLE
chore: minor eslint config changes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,3 @@ dist/
 # dependencies
 flow-typed/
 node_modules/
-
-# misc
-*.flow

--- a/.eslintrc
+++ b/.eslintrc
@@ -36,11 +36,6 @@
     }
   },
   "rules": {
-    "class-methods-use-this": "off",
-    "comma-dangle": [
-      "error",
-      "only-multiline"
-    ],
     "no-restricted-syntax": [
       "error",
       "ForInStatement",


### PR DESCRIPTION
Adds back [class-methods-use-this](https://eslint.org/docs/rules/class-methods-use-this). Also removes [comma-dangle](https://eslint.org/docs/rules/comma-dangle) since [prettier](https://github.com/prettier/prettier) already enforces trailing commas.