### PR TITLE
refactor: remove redundant unit tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,11 +36,6 @@
     }
   },
   "rules": {
-    "no-restricted-syntax": [
-      "error",
-      "ForInStatement",
-      "WithStatement"
-    ],
     "prettier/prettier": ["error", {
       "parser": "babylon",
       "semi": false,

--- a/packages/ouro-core/src/__tests__/methods.js
+++ b/packages/ouro-core/src/__tests__/methods.js
@@ -2,14 +2,6 @@
 
 import * as ouro from '../'
 
-test('#@@iterator()', () => {
-  const source = [1, 2, 3]
-
-  for (const value of ouro.from(source)) {
-    expect(source.includes(value)).toBe(true)
-  }
-})
-
 test('#collect()', () => {
   expect(ouro.from('test').collect()).toMatchSnapshot()
   expect(ouro.from('test').collect(Set)).toMatchSnapshot()

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/chain.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/chain.js.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `1`;
-
-exports[`#@@iterator() 2`] = `2`;
-
-exports[`#@@iterator() 3`] = `3`;
-
-exports[`#@@iterator() 4`] = `4`;
-
-exports[`#@@iterator() 5`] = `5`;
-
-exports[`#@@iterator() 6`] = `6`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/enumerate.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/enumerate.js.snap
@@ -1,26 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `
-Array [
-  0,
-  1,
-]
-`;
-
-exports[`#@@iterator() 2`] = `
-Array [
-  1,
-  2,
-]
-`;
-
-exports[`#@@iterator() 3`] = `
-Array [
-  2,
-  3,
-]
-`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/filter-map.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/filter-map.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `1`;
-
-exports[`#@@iterator() 2`] = `2`;
-
-exports[`#@@iterator() 3`] = `3`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/filter.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/filter.js.snap
@@ -1,9 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `2`;
-
-exports[`#@@iterator() 2`] = `3`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/flat-map.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/flat-map.js.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `1`;
-
-exports[`#@@iterator() 2`] = `1`;
-
-exports[`#@@iterator() 3`] = `2`;
-
-exports[`#@@iterator() 4`] = `2`;
-
-exports[`#@@iterator() 5`] = `3`;
-
-exports[`#@@iterator() 6`] = `3`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/map.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/map.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `2`;
-
-exports[`#@@iterator() 2`] = `4`;
-
-exports[`#@@iterator() 3`] = `6`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/skip-while.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/skip-while.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `4`;
-
-exports[`#@@iterator() 2`] = `5`;
-
-exports[`#@@iterator() 3`] = `6`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/skip.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/skip.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `4`;
-
-exports[`#@@iterator() 2`] = `5`;
-
-exports[`#@@iterator() 3`] = `6`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/take-while.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/take-while.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `1`;
-
-exports[`#@@iterator() 2`] = `2`;
-
-exports[`#@@iterator() 3`] = `3`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/take.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/take.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `"test"`;
-
-exports[`#@@iterator() 2`] = `"test"`;
-
-exports[`#@@iterator() 3`] = `"test"`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/tap.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/tap.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `1`;
-
-exports[`#@@iterator() 2`] = `2`;
-
-exports[`#@@iterator() 3`] = `3`;
-
 exports[`#next() 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/__snapshots__/zip.js.snap
+++ b/packages/ouro-core/src/adapter/__tests__/__snapshots__/zip.js.snap
@@ -1,26 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#@@iterator() 1`] = `
-Array [
-  "test",
-  1,
-]
-`;
-
-exports[`#@@iterator() 2`] = `
-Array [
-  "test",
-  2,
-]
-`;
-
-exports[`#@@iterator() 3`] = `
-Array [
-  "test",
-  3,
-]
-`;
-
 exports[`#next() with a bound lhs and an unbound rhs 1`] = `
 Object {
   "done": false,

--- a/packages/ouro-core/src/adapter/__tests__/chain.js
+++ b/packages/ouro-core/src/adapter/__tests__/chain.js
@@ -21,12 +21,6 @@ afterEach(() => {
   subj.producerB.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producerA.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/enumerate.js
+++ b/packages/ouro-core/src/adapter/__tests__/enumerate.js
@@ -17,12 +17,6 @@ afterEach(() => {
   subj.producer.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producer.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/filter-map.js
+++ b/packages/ouro-core/src/adapter/__tests__/filter-map.js
@@ -17,12 +17,6 @@ afterEach(() => {
   subj.producer.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producer.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/filter.js
+++ b/packages/ouro-core/src/adapter/__tests__/filter.js
@@ -17,12 +17,6 @@ afterEach(() => {
   subj.producer.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producer.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/flat-map.js
+++ b/packages/ouro-core/src/adapter/__tests__/flat-map.js
@@ -22,12 +22,6 @@ afterEach(() => {
   subj.parent.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.parent.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/map.js
+++ b/packages/ouro-core/src/adapter/__tests__/map.js
@@ -17,12 +17,6 @@ afterEach(() => {
   subj.producer.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producer.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/skip-while.js
+++ b/packages/ouro-core/src/adapter/__tests__/skip-while.js
@@ -17,12 +17,6 @@ afterEach(() => {
   subj.producer.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producer.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/skip.js
+++ b/packages/ouro-core/src/adapter/__tests__/skip.js
@@ -17,12 +17,6 @@ afterEach(() => {
   subj.producer.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producer.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/take-while.js
+++ b/packages/ouro-core/src/adapter/__tests__/take-while.js
@@ -17,12 +17,6 @@ afterEach(() => {
   subj.producer.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producer.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/take.js
+++ b/packages/ouro-core/src/adapter/__tests__/take.js
@@ -17,12 +17,6 @@ afterEach(() => {
   subj.producer.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producer.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/tap.js
+++ b/packages/ouro-core/src/adapter/__tests__/tap.js
@@ -19,12 +19,6 @@ afterEach(() => {
   subj.producer.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producer.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/adapter/__tests__/zip.js
+++ b/packages/ouro-core/src/adapter/__tests__/zip.js
@@ -27,12 +27,6 @@ afterEach(() => {
   subj.producerB.drop.mockReset()
 })
 
-test('#@@iterator()', () => {
-  for (const item of subj) {
-    expect(item).toMatchSnapshot()
-  }
-})
-
 test('#drop()', () => {
   expect(subj.drop()).toBeUndefined()
   expect(subj.producerA.drop).toHaveBeenCalled()

--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/cycle.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/cycle.js.snap
@@ -22,3 +22,59 @@ Cycle {
   "state": 0,
 }
 `;
+
+exports[`#next() 1`] = `
+Object {
+  "done": false,
+  "value": "t",
+}
+`;
+
+exports[`#next() 2`] = `
+Object {
+  "done": false,
+  "value": "e",
+}
+`;
+
+exports[`#next() 3`] = `
+Object {
+  "done": false,
+  "value": "s",
+}
+`;
+
+exports[`#next() 4`] = `
+Object {
+  "done": false,
+  "value": "t",
+}
+`;
+
+exports[`#next() 5`] = `
+Object {
+  "done": false,
+  "value": "t",
+}
+`;
+
+exports[`#next() 6`] = `
+Object {
+  "done": false,
+  "value": "e",
+}
+`;
+
+exports[`#next() 7`] = `
+Object {
+  "done": false,
+  "value": "s",
+}
+`;
+
+exports[`#next() 8`] = `
+Object {
+  "done": false,
+  "value": "t",
+}
+`;

--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/indexed.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/indexed.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Indexed source array #@@iterator() 1`] = `1`;
-
-exports[`Indexed source array #@@iterator() 2`] = `2`;
-
-exports[`Indexed source array #@@iterator() 3`] = `3`;
-
 exports[`Indexed source array #constructor() 1`] = `
 Indexed {
   "index": 0,
@@ -30,14 +24,6 @@ Indexed {
   "source": Array [],
 }
 `;
-
-exports[`Indexed source string #@@iterator() 1`] = `"t"`;
-
-exports[`Indexed source string #@@iterator() 2`] = `"e"`;
-
-exports[`Indexed source string #@@iterator() 3`] = `"s"`;
-
-exports[`Indexed source string #@@iterator() 4`] = `"t"`;
 
 exports[`Indexed source string #constructor() 1`] = `
 Indexed {

--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/range.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/range.js.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Chars <- #@@iterator() 1`] = `"c"`;
-
-exports[`Chars <- #@@iterator() 2`] = `"b"`;
-
-exports[`Chars <- #@@iterator() 3`] = `"a"`;
-
 exports[`Chars <- #constructor() 1`] = `
 Chars {
   "size": 3,
@@ -81,12 +75,6 @@ Object {
 }
 `;
 
-exports[`Chars -> #@@iterator() 1`] = `"a"`;
-
-exports[`Chars -> #@@iterator() 2`] = `"b"`;
-
-exports[`Chars -> #@@iterator() 3`] = `"c"`;
-
 exports[`Chars -> #drop() 1`] = `
 Object {
   "done": true,
@@ -135,12 +123,6 @@ Object {
   "value": undefined,
 }
 `;
-
-exports[`Numbers <- #@@iterator() 1`] = `3`;
-
-exports[`Numbers <- #@@iterator() 2`] = `2`;
-
-exports[`Numbers <- #@@iterator() 3`] = `1`;
 
 exports[`Numbers <- #constructor() 1`] = `
 Numbers {
@@ -207,12 +189,6 @@ Object {
   "value": undefined,
 }
 `;
-
-exports[`Numbers -> #@@iterator() 1`] = `1`;
-
-exports[`Numbers -> #@@iterator() 2`] = `2`;
-
-exports[`Numbers -> #@@iterator() 3`] = `3`;
 
 exports[`Numbers -> #constructor() 1`] = `
 Numbers {

--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/unbound.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/unbound.js.snap
@@ -2,6 +2,6 @@
 
 exports[`#constructor() 1`] = `
 Unbound {
-  "source":  {},
+  "source": Object {},
 }
 `;

--- a/packages/ouro-core/src/producer/__tests__/cycle.js
+++ b/packages/ouro-core/src/producer/__tests__/cycle.js
@@ -13,21 +13,22 @@ test('#constructor()', () => {
   expect(producer).toMatchSnapshot()
 })
 
-test('#@@iterator()', () => {
-  let i = 0
-
-  for (const item of producer) {
-    if (i > SOURCE.length * 3) {
-      break
-    }
-
-    expect(SOURCE).toContain(item)
-    i += 1
-  }
-})
-
 test('#drop()', () => {
   expect(producer.drop()).toBeUndefined()
   expect(producer.next()).toMatchSnapshot()
   expect(producer).toMatchSnapshot()
+})
+
+test('#next()', () => {
+  // First cycle...
+  expect(producer.next()).toMatchSnapshot()
+  expect(producer.next()).toMatchSnapshot()
+  expect(producer.next()).toMatchSnapshot()
+  expect(producer.next()).toMatchSnapshot()
+
+  // Second cycle...
+  expect(producer.next()).toMatchSnapshot()
+  expect(producer.next()).toMatchSnapshot()
+  expect(producer.next()).toMatchSnapshot()
+  expect(producer.next()).toMatchSnapshot()
 })

--- a/packages/ouro-core/src/producer/__tests__/indexed.js
+++ b/packages/ouro-core/src/producer/__tests__/indexed.js
@@ -16,12 +16,6 @@ describe('Indexed', () => {
       expect(producer).toMatchSnapshot()
     })
 
-    test('#@@iterator()', () => {
-      for (const item of producer) {
-        expect(item).toMatchSnapshot()
-      }
-    })
-
     test('#drop()', () => {
       expect(producer.drop()).toBeUndefined()
       expect(producer.next()).toMatchSnapshot()
@@ -40,12 +34,6 @@ describe('Indexed', () => {
 
     test('#constructor()', () => {
       expect(producer).toMatchSnapshot()
-    })
-
-    test('#@@iterator()', () => {
-      for (const item of producer) {
-        expect(item).toMatchSnapshot()
-      }
     })
 
     test('#drop()', () => {

--- a/packages/ouro-core/src/producer/__tests__/range.js
+++ b/packages/ouro-core/src/producer/__tests__/range.js
@@ -19,12 +19,6 @@ describe('Numbers', () => {
       expect(new Numbers('dog', 'cat')).toMatchSnapshot()
     })
 
-    test('#@@iterator()', () => {
-      for (const item of producer) {
-        expect(item).toMatchSnapshot()
-      }
-    })
-
     test('#drop()', () => {
       expect(producer.drop()).toBeUndefined()
       expect(producer.next()).toMatchSnapshot()
@@ -47,12 +41,6 @@ describe('Numbers', () => {
     test('#constructor()', () => {
       expect(new Numbers(3, 1)).toMatchSnapshot()
       expect(new Numbers(Infinity, 1)).toMatchSnapshot()
-    })
-
-    test('#@@iterator()', () => {
-      for (const item of producer) {
-        expect(item).toMatchSnapshot()
-      }
     })
 
     test('#drop()', () => {
@@ -78,12 +66,6 @@ describe('Chars', () => {
       producer = new Chars('a', 'c')
     })
 
-    test('#@@iterator()', () => {
-      for (const item of producer) {
-        expect(item).toMatchSnapshot()
-      }
-    })
-
     test('#drop()', () => {
       expect(producer.drop()).toBeUndefined()
       expect(producer.next()).toMatchSnapshot()
@@ -106,12 +88,6 @@ describe('Chars', () => {
     test('#constructor()', () => {
       expect(producer).toMatchSnapshot()
       expect(new Chars()).toMatchSnapshot()
-    })
-
-    test('#@@iterator()', () => {
-      for (const item of producer) {
-        expect(item).toMatchSnapshot()
-      }
     })
 
     test('#drop()', () => {

--- a/packages/ouro-core/src/producer/__tests__/repeat.js
+++ b/packages/ouro-core/src/producer/__tests__/repeat.js
@@ -13,19 +13,6 @@ test('#constructor()', () => {
   expect(producer).toMatchSnapshot()
 })
 
-test('#@@iterator()', () => {
-  let i = 0
-
-  for (const item of producer) {
-    if (i > 3) {
-      break
-    }
-
-    expect(item).toBe(ITEM)
-    i += 1
-  }
-})
-
 test('#drop()', () => {
   expect(producer.drop()).toBeUndefined()
   expect(producer.next()).toMatchSnapshot()

--- a/packages/ouro-core/src/producer/__tests__/unbound.js
+++ b/packages/ouro-core/src/producer/__tests__/unbound.js
@@ -2,36 +2,15 @@
 
 import Unbound from '../unbound'
 
-function* randomRepeat(value, amount) {
-  const exit = Math.round(amount / 2)
-
-  while (Math.round(Math.random() * amount) !== exit) {
-    yield value
-  }
-}
-
-const ITEM = 'test'
+const ITEM = new Set('test')
 let producer
 
 beforeEach(() => {
-  producer = new Unbound(randomRepeat(ITEM, 5))
+  producer = new Unbound(ITEM.values())
 })
 
 test('#constructor()', () => {
   expect(producer).toMatchSnapshot()
-})
-
-test('#@@iterator()', () => {
-  let i = 0
-
-  for (const item of producer) {
-    if (i > 3) {
-      break
-    }
-
-    expect(item).toBe(ITEM)
-    i += 1
-  }
 })
 
 test('#drop()', () => {


### PR DESCRIPTION
Removes redundant `@@iterator` method tests. Also makes `ouro` 100% free of imperative 🔁.