### PR TITLE
fix: do not remove value when repeat is dropped

### DIFF
--- a/packages/ouro-core/src/producer/__tests__/__snapshots__/repeat.js.snap
+++ b/packages/ouro-core/src/producer/__tests__/__snapshots__/repeat.js.snap
@@ -17,6 +17,6 @@ Object {
 exports[`#drop() 2`] = `
 Repeat {
   "done": true,
-  "value": undefined,
+  "value": "test",
 }
 `;

--- a/packages/ouro-core/src/producer/repeat.js
+++ b/packages/ouro-core/src/producer/repeat.js
@@ -19,8 +19,6 @@ export default class Repeat<T> implements Drop, Iterator<T> {
 
   drop(): void {
     this.done = true
-    // $FlowIgnore
-    this.value = undefined
   }
 
   next(): IteratorResult<T, void> {


### PR DESCRIPTION
This cleanup work was unnecessary and could potentially lead to bugs.