### PR TITLE
test: make flatten unit test more specific

### DIFF
--- a/packages/ouro-core/src/__tests__/adapters.js
+++ b/packages/ouro-core/src/__tests__/adapters.js
@@ -77,7 +77,7 @@ test('#flatten()', () => {
   const subj = ouro.range()
 
   subj.flatten()
-  expect(FlatMap).toHaveBeenLastCalledWith(subj.producer, expect.any(Function))
+  expect(FlatMap).toHaveBeenLastCalledWith(subj.producer, identity)
 })
 
 test('#map()', () => {


### PR DESCRIPTION
This is better now that we are no longer passing an anonymous function in to `flatMap`. 